### PR TITLE
Adapt readme

### DIFF
--- a/KreditSmart/antragsstatus/README.md
+++ b/KreditSmart/antragsstatus/README.md
@@ -1,3 +1,5 @@
 # KEX-Antragsstatus-API
 
-Diese Dokumentation ist umgezogen: https://github.com/europace/kex-antragsstatus-api
+Wir haben eine neue Webseite: https://developer.europace.de/
+
+Diese Webseite bietet Ihnen eine Übersicht aller APIs in Europace.

--- a/KreditSmart/dokumente/README.md
+++ b/KreditSmart/dokumente/README.md
@@ -1,4 +1,5 @@
 # KEX-Dokumente-Import-API 
 
-Diese Dokumentation ist umgezogen: https://github.com/europace/kex-dokumente-import-api
-
+WWir haben eine neue Webseite: https://developer.europace.de/
+ 
+ Diese Webseite bietet Ihnen eine Übersicht aller APIs in Europace.

--- a/KreditSmart/vorgaenge/README.md
+++ b/KreditSmart/vorgaenge/README.md
@@ -1,5 +1,5 @@
 # KEX-Vorgang-Import und -Export 
 
-Diese Dokumentation der KEX-Vorgang-Import API ist umgezogen: https://github.com/europace/kex-vorgaenge-api
+Wir haben eine neue Webseite: https://developer.europace.de/
 
-Die Dokumentation der KEX-Vorgang-Export API befindet sich unter: https://github.com/europace/kex-vorgang-export-api
+Diese Webseite bietet Ihnen eine Übersicht aller APIs in Europace.

--- a/README.md
+++ b/README.md
@@ -3,69 +3,8 @@ EUROPACE 2 API Dokumentation
 
 Dokumentation der öffentlichen Schnittstellen der EUROPACE 2 Platform.
 
-Hier finden sie weiterführende Dokumentation zu den folgenden Bereichen.
+Wir haben eine neue Webseite: https://developer.europace.de/
+
+Diese Webseite bietet Ihnen eine Übersicht aller APIs in Europace.
 
 Bei Fragen und Anregungen bitte eine Email an [devsupport@europace2.de](mailto:devsupport@europace2.de) schreiben.
-
-# KreditSmart Extern (KEX) APIs
-Dokumentation der öffentlichen Schnittstellen des **Kredit**Smart Moduls.
-
-## KEX-Antragsstatus-API
-Diese Schnittstelle ermöglicht es, den Status eines Antrags zu verändern oder den aktuellen Status um Zusatzinformationen zu ergänzen.
-Die Dokumentation befindet sich hier: (https://github.com/hypoport/europace2-api/tree/master/KreditSmart/antragsstatus)
-
-## KEX-Vorgang-Import-API
-Die Schnittstelle ermöglicht das automatisierte Anlegen von Vorgängen in KreditSmart.
-Die Dokumentation befindet sich hier: (https://github.com/hypoport/europace2-api/tree/master/KreditSmart/vorgaenge)
-
----
-
-# BaufiSmart Extern APIs
-
-## Anträge Auslesen API
-API Definition zum Auslesen von Anträgen aus der Europace-Plattform aus Sicht eines Produktanbieters.
-Die Dokumentation bedindet sich hier:  (https://github.com/hypoport/antraege-auslesen-api).
-
-## Finanzierungsvorschläge (Ergebnisliste) API
-API zum Erstellen von Finanzierungsvorschlägen basierend auf den Angaben der Erfassten Daten der [Vorgänge API](https://github.com/hypoport/europace2-api/tree/master/BaufiSmart/vorgaenge-api).
-Die Dokumentation befindet sich hier:  (https://github.com/hypoport/finanzierungsvorschlaege-api).
-
-## Vorgänge API
-API Definition zum Auslesen von Vorgängen aus der Europace-Plattform aus Sicht eines Vertriebes.
-Die Dokumentation befindet sich hier:  (https://github.com/hypoport/vorgaenge-api).
-
-## Externe Dokumente API
-Diese Schnittstelle ermöglicht es, Dokumente einem BaufiSmart Vorgang hinzuzufügen. (https://github.com/hypoport/europace2-api/tree/master/BaufiSmart/dokumente)
-
-## Vorgang Anlegen (BEX)
-API zum automatisierten Anlegen von Vorgängen.
-Die Dokumentation befindet sich hier: (https://github.com/europace/baufismart-vorgang-anlegen-api)
-
-## Ereignisse APIs
-Die Ereignisse-API liefert die Ereignisse eines Vorgangs inkl. Zeitpunkt, Typ, Ersteller, Text und ggf. verlinkter Dokumente zurück.
-(https://github.com/hypoport/ep-ereignisse-api)
-
-## Prolongation
-
-Um einen bestehenden BaufiSmart Vorgang zu prolongieren gehen sie wie folgt vor: (https://github.com/hypoport/europace2-api/tree/master/BaufiSmart/prolongation)
-
-## API zur Abfrage von Darlehensdaten für Produktanbieter
-
-Die Dokumentation befindet sich hier: (https://github.com/hypoport/europace2-api/tree/master/Produktanbieterdarlehensdaten)
-
----
-# Dokumenten API
-API Rund um Platform dokumente.
-(https://github.com/hypoport/ep-dokumente-api)
-
----
-
-# Reporting
-Folgende Reports können sie beziehen: Vorgänge, Teilanträge, Bausteine, Provisionen
-Mehr Erfahren sie hier: (https://github.com/hypoport/europace2-api/tree/master/Reporting)
-
----
-
-# Partnermanagement Extern (PEX) APIs
- Unter dem Akronym "PEX" sind alle API's versammelt, welche zur externen Steuerung des EUROPACE 2 Moduls Partnermanagement (Einstellungen) verwendet werden.
-Die Dokumentation befindet sich hier: (https://github.com/hypoport/europace2-api/tree/master/Partnermanagement)


### PR DESCRIPTION
Wie besprochen passe ich die Readmes an um auf unsere neue Webseite zu verweisen.

Ich habe es auch für die KS-eigenen Readmes gemacht, da vereinzelte Partner evtl. einen harte link auf diese Seiten haben.

Soll das für den Rest der APIs auch passieren?